### PR TITLE
support <audio> tags

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ function WebAudioAnalyser(audio, ctx, opts) {
   this.ctx = ctx = ctx || new AudioContext
 
   if (!(audio instanceof AudioNode)) {
-    audio = audio instanceof Audio
+    audio = (audio instanceof Audio || audio instanceof HTMLAudioElement)
       ? ctx.createMediaElementSource(audio)
       : ctx.createMediaStreamSource(audio)
   }


### PR DESCRIPTION
Right now it only seems to work in Chrome with `new Audio()`. This patch will also support `document.createElement('audio')`.