### PR TITLE
Fixed demo by moving sample audio into repo (avoids CORS)

### DIFF
--- a/demo.js
+++ b/demo.js
@@ -1,4 +1,4 @@
-var song_url
+var song_url = './audio.mp3'
 
 var fs           = require('fs')
 var analyse      = require('./')
@@ -11,20 +11,10 @@ var glnow        = require('gl-now')
 var mat4         = GLMatrix.mat4
 var shell
 
-require('soundcloud-badge')({
-    client_id: 'ded451c6d8f9ff1c62f72523f49dab68'
-  , song: 'https://soundcloud.com/moon_music/hydrogen'
-  , dark: false
-  , getFonts: true
-}, function(err, src, json, div) {
-  if (err) throw err
-  song_url = src
-
-  shell = glnow({ clearColor: [0, 0, 0, 1] })
-  shell.on('gl-render', render)
-  shell.on('gl-init', init)
-  camera = createCamera(shell)
-})
+shell = glnow({ clearColor: [0, 0, 0, 1] })
+shell.on('gl-render', render)
+shell.on('gl-init', init)
+camera = createCamera(shell)
 
 var lines = new Float32Array(1024 * 3)
 var sides = new Float32Array(1024 * 3)
@@ -35,7 +25,7 @@ var gl
 
 function init() {
   var audio  = new Audio
-  audio.crossOrigin = 'Anonymous'
+  audio.crossOrigin = 'anonymous'
   audio.src = song_url
   audio.loop = true
   audio.addEventListener('canplay', function() {

--- a/index.html
+++ b/index.html
@@ -2,8 +2,14 @@
 <html>
   <head>
     <title>web-audio-analyser</title>
+    <style>
+        span { color: white; position: absolute; z-index: 10; }
+        a { color: white; }
+        a:visited { color: white; }
+    </style>
   </head>
   <body>
+      <span>Moonlight Reprise by Kai Engel CC BY-NC 3.0, <a href="http://freemusicarchive.org/music/Kai_Engel/Irsens_Tale/Kai_Engel_-_Irsens_Tale_-_04_Moonlight_Reprise">available on the Free Music Archive</a></span>
     <script type="text/javascript" src="bundle.js"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
     "gl-matrix": "~2.0.0",
     "gl-now": "0.0.4",
     "gl-shader": "0.0.6",
-    "gl-vao": "0.0.2",
-    "soundcloud-badge": "0.0.0"
+    "gl-vao": "0.0.2"
   },
   "dependencies": {},
   "repository": {


### PR DESCRIPTION
Soundcloud doesn't serve audio with the CORS header, so it's not possible to run it through an AnalyserNode. To remedy this I've included a audio sample in the repository itself, in order to avoid the CORS problems. The audio is licensed CC-BY-NC 3.0, available at http://freemusicarchive.org/music/Kai_Engel/Irsens_Tale/Kai_Engel_-_Irsens_Tale_-_04_Moonlight_Reprise I've included attribution on the demo.html page. 
